### PR TITLE
修复self.proxy为None时产生的报错

### DIFF
--- a/live_recorder.py
+++ b/live_recorder.py
@@ -71,11 +71,17 @@ class LiveRecoder:
             raise ConnectionError(f'{self.flag}直播检测请求错误\n{repr(error)}')
 
     def get_client(self):
+        # 检查是否有设置代理
+        if self.proxy:
+            transport = AsyncProxyTransport.from_url(self.proxy)
+        else:
+            transport = None
+
         return httpx.AsyncClient(
             http2=True,
             timeout=self.interval,
             limits=httpx.Limits(max_keepalive_connections=100, keepalive_expiry=self.interval * 2),
-            transport=AsyncProxyTransport.from_url(self.proxy),
+            transport=transport,
             headers=self.headers,
             cookies=self.cookies
         )


### PR DESCRIPTION
您好，
我发现当self.proxy被设置为None时，原始方法会引发错误。所以用GPT改吧改吧修复一下（希望能有所帮助~）
### 报错内容：
  Traceback (most recent call last):
  File "live_recorder.py", line 437, in <module>
  File "asyncio/runners.py", line 44, in run
  File "asyncio/base_events.py", line 649, in run_until_complete
  File "live_recorder.py", line 418, in run
  File "live_recorder.py", line 44, in __init__
  File "live_recorder.py", line 78, in get_client
  File "httpx_socks/_async_transport.py", line 95, in from_url
  File "python_socks/_helpers.py", line 57, in parse_proxy_url
ValueError: Invalid scheme component: b''
[7] Failed to execute script 'live_recorder' due to unhandled exception!
### 主要改动:
在初始化AsyncClient之前，增加了对self.proxy值的检查。
如果self.proxy为None，则不再调用AsyncProxyTransport.from_url，而是直接为transport赋值为None。
仅在self.proxy具有有效值时，才调用AsyncProxyTransport.from_url方法。